### PR TITLE
Fix 'format not a string literal and no format arguments [-Werror=format-security]'

### DIFF
--- a/ext/digest/displayIntermediateValues.c
+++ b/ext/digest/displayIntermediateValues.c
@@ -110,7 +110,7 @@ void displayRoundNumber(int level, unsigned int i)
 void displayText(int level, const char *text)
 {
     if ((intermediateValueFile) && (level <= displayLevel)) {
-        fprintf(intermediateValueFile, text);
+        fprintf(intermediateValueFile, "%s", text);
         fprintf(intermediateValueFile, "\n");
         fprintf(intermediateValueFile, "\n");
     }


### PR DESCRIPTION
I'd like to add a simple fix. The problem is that at least in Ubuntu gcc has "-Wformat-security" as a default flag, and together with "-Werror=format-security" they lead to an error if fprintf is used without format string (https://wiki.ubuntu.com/ToolChain/CompilerFlags#A-Wformat_-Wformat-security). The issue is #7 