### PR TITLE
Relax ruby version dependency check 

### DIFF
--- a/digest-sha3.gemspec
+++ b/digest-sha3.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.description = "The SHA-3 (Keccak) hash."
   s.authors = ["Hongli Lai (Phusion)", "Keccak authors"]
   s.extensions << "ext/digest/extconf.rb"
-  s.required_ruby_version = "~> 2.2"
+  s.required_ruby_version = "> 2.2"
   s.license = "MIT"
 
   s.files = Dir[


### PR DESCRIPTION
Allow this gem to be used with ruby 3 

if you need I can bump the gem version as well in this PR or any other changes, let me know

